### PR TITLE
35 allow multivalued parameter

### DIFF
--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -181,6 +181,15 @@ func updateReferences(model schema.Model, response dbResponse) {
 			key := strings.ToLower(fmt.Sprintf("%s.%s", response.table, k))
 			if _, exist := model.Refs[key]; exist {
 				model.Refs[key] = v
+			} else {
+				key = strings.ToLower(fmt.Sprintf("%s.%s[@]", response.table, k))
+				if _, exist = model.Refs[key]; exist {
+					if model.Refs[key] == nil {
+						model.Refs[key] = make([]interface{}, 0)
+					}
+
+					model.Refs[key] = append(model.Refs[key].([]interface{}), v)
+				}
 			}
 		}
 	}

--- a/extractor/extractor_test.go
+++ b/extractor/extractor_test.go
@@ -102,8 +102,12 @@ func (HumanResourcesReader) FetchColumnsMetadata(table schema.Table) ([]reader.D
 	case table.Name == "jobs":
 		return []reader.DBColumn{
 			{Name: "id", Type: "int"},
-			{Name: "employee_id", Type: "int"},
 			{Name: "title", Type: "varchar"},
+		}, nil
+	case table.Name == "job_history":
+		return []reader.DBColumn{
+			{Name: "department_id", Type: "int"},
+			{Name: "employee_id", Type: "int"},
 		}, nil
 	default:
 		return []reader.DBColumn{}, nil
@@ -192,6 +196,50 @@ func (HumanResourcesReader) FetchData(table string, _ []reader.DBColumn, _ []sch
 		m["id"] = 3
 		m["name"] = "América do Sul"
 		return []map[string]interface{}{m}, nil
+	case table == "jobs":
+		m1 := make(map[string]interface{})
+		m1["id"] = 1
+		m1["title"] = "junior developer"
+
+		m2 := make(map[string]interface{})
+		m2["id"] = 2
+		m2["title"] = "full developer"
+
+		m3 := make(map[string]interface{})
+		m3["id"] = 3
+		m3["title"] = "senior developer"
+
+		m4 := make(map[string]interface{})
+		m4["id"] = 4
+		m4["title"] = "seller"
+
+		m5 := make(map[string]interface{})
+		m5["id"] = 5
+		m5["title"] = "sell manager"
+
+		return []map[string]interface{}{m1, m2, m3, m4, m5}, nil
+	case table == "job_history":
+		m1 := make(map[string]interface{})
+		m1["employee_id"] = 100
+		m1["job_id"] = 4
+
+		m2 := make(map[string]interface{})
+		m2["employee_id"] = 100
+		m2["job_id"] = 5
+
+		m3 := make(map[string]interface{})
+		m3["employee_id"] = 101
+		m3["job_id"] = 1
+
+		m4 := make(map[string]interface{})
+		m4["employee_id"] = 101
+		m4["job_id"] = 2
+
+		m5 := make(map[string]interface{})
+		m5["employee_id"] = 101
+		m5["job_id"] = 3
+
+		return []map[string]interface{}{m1, m2, m3, m4, m5}, nil
 	default:
 		return []map[string]interface{}{}, nil
 	}

--- a/extractor/extractor_test.go
+++ b/extractor/extractor_test.go
@@ -72,6 +72,7 @@ func (HumanResourcesReader) FetchColumnsMetadata(table schema.Table) ([]reader.D
 		return []reader.DBColumn{
 			{Name: "id", Type: "int"},
 			{Name: "department_id", Type: "int"},
+			{Name: "job_id_id", Type: "int"},
 			{Name: "first_name", Type: "varchar"},
 			{Name: "last_name", Type: "varchar"},
 		}, nil
@@ -162,12 +163,14 @@ func (HumanResourcesReader) FetchData(table string, _ []reader.DBColumn, _ []sch
 		m1 := make(map[string]interface{})
 		m1["id"] = 100
 		m1["department_id"] = 90
+		m1["job_id"] = 5
 		m1["first_name"] = "Antonio"
 		m1["last_name"] = "Vivaldi"
 
 		m2 := make(map[string]interface{})
 		m2["id"] = 101
 		m2["department_id"] = 90
+		m2["job_id"] = 3
 		m2["first_name"] = "Johann"
 		m2["last_name"] = "Bach"
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -17,7 +17,7 @@ var (
 	ErrSchemaValidation    = errors.New("validation")
 	ErrTableClassification = errors.New("classification")
 	nameRegExp             = regexp.MustCompile(`^[a-zA-Z_]\w+$`)
-	filterReferenceRegExp  = regexp.MustCompile(`^\$\{(\w+)\.(\w+)\}$`)
+	filterReferenceRegExp  = regexp.MustCompile(`^\$\{(\w+)\.(\w+(\[@\])?)\}$`)
 )
 
 type Converter string

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -126,7 +126,7 @@ func TestDigestSchemaReferences(t *testing.T) {
 		keys = append(keys, k)
 	}
 
-	assert.Len(t, keys, 7)
+	assert.Len(t, keys, 8)
 	assert.Contains(t, schema.Refs, "b1.id")
 	assert.Contains(t, schema.Refs, "a11.id")
 	assert.Contains(t, schema.Refs, "b1312.id")
@@ -134,6 +134,7 @@ func TestDigestSchemaReferences(t *testing.T) {
 	assert.Contains(t, schema.Refs, "b13.id")
 	assert.Contains(t, schema.Refs, "b131.id")
 	assert.Contains(t, schema.Refs, "c1.id")
+	assert.Contains(t, schema.Refs, "a11.id[@]")
 }
 
 func TestSelectColumns(t *testing.T) {

--- a/test/unit/extractor_multivalued_test.yml
+++ b/test/unit/extractor_multivalued_test.yml
@@ -1,0 +1,26 @@
+---
+tables:
+  - name: employees
+    filters:
+      - name: department_id
+        value: ${departments.id}
+  - name: departments
+    filters:
+      - name: department_id
+        value: ${department_id}
+  - name: locations
+    filters:
+      - name: location_id
+        value: ${departments.location_id}
+  - name: countries
+    filters:
+      - name: country_id
+        value: ${locations.country_id}
+  - name: regions
+    filters:
+      - name: region_id
+        value: ${countries.region_id}
+  - name: jobs
+    filters:
+      - name: job_id
+        value: ${employees.job_id[@]}

--- a/test/unit/extractor_multivalued_test.yml
+++ b/test/unit/extractor_multivalued_test.yml
@@ -23,4 +23,8 @@ tables:
   - name: jobs
     filters:
       - name: job_id
-        value: ${employees.job_id[@]}
+        value: ${job_history.job_id[@]}
+  - name: job_history
+    filters:
+      - name: employee_id
+        value: ${employees.id[@]}

--- a/test/unit/schema_test_grouping.yml
+++ b/test/unit/schema_test_grouping.yml
@@ -54,4 +54,4 @@ tables:
       - name: any
         value: 5
       - name: a11_fk
-        value: ${a11.id}
+        value: ${a11.id[@]}


### PR DESCRIPTION
Allows use of "[@]" in reference parameters like "${table.field[@]". Closes #35.