### PR TITLE
55 improve error message when no metadata is found

### DIFF
--- a/reader/oracle.go
+++ b/reader/oracle.go
@@ -44,7 +44,7 @@ func (r OracleReader) FetchColumnsMetadata(table schema.Table) ([]DBColumn, erro
 	if rows.Err() != nil {
 		return nil, rows.Err()
 	} else if len(records) == 0 {
-		return nil, fmt.Errorf("no metadata found in table %s (lack of permission?)", table.Name)
+		return nil, fmt.Errorf("no metadata found for table %s (make sure it exists and user has proper grants)", table.Name)
 	}
 
 	return records, nil

--- a/reader/oracle_test.go
+++ b/reader/oracle_test.go
@@ -234,7 +234,7 @@ func TestFetchColumnsMetadataEmptyResultError(t *testing.T) {
 	mock.ExpectQuery("^SELECT (.+) FROM  ALL_TAB_COLS").WillReturnRows(rows)
 
 	_, err = r.FetchColumnsMetadata(schema.Table{Name: "customers", Ignore: []schema.Ignore{"id"}})
-	assert.Equal(t, "no metadata found in table customers (lack of permission?)", err.Error())
+	assert.Equal(t, "no metadata found for table customers (make sure it exists and user has proper grants)", err.Error())
 }
 
 func TestFetchData(t *testing.T) {


### PR DESCRIPTION
Improve error message when no metadata is found. Closes #55.