### PR TITLE
77 readers must return a list metadata and data

### DIFF
--- a/dataconv/blob_converter.go
+++ b/dataconv/blob_converter.go
@@ -7,7 +7,7 @@ import (
 
 type BlobConverter struct{}
 
-func (BlobConverter) Convert(source interface{}) (interface{}, error) {
+func (BlobConverter) Convert(_ string, source interface{}) (interface{}, error) {
 	bts, isArrByte := source.([]byte)
 	if !isArrByte {
 		return nil, fmt.Errorf("'%v' is not []byte", source)

--- a/dataconv/blob_converter_test.go
+++ b/dataconv/blob_converter_test.go
@@ -11,7 +11,7 @@ import (
 func TestConvertBytesSourceIsNotBytes(t *testing.T) {
 	c := dataconv.BlobConverter{}
 	source := "test"
-	actual, err := c.Convert(source)
+	actual, err := c.Convert("blob", source)
 
 	assert.Equal(t, "'test' is not []byte", err.Error())
 	assert.Nil(t, actual)
@@ -21,7 +21,7 @@ func TestConvertBytes(t *testing.T) {
 	c := dataconv.BlobConverter{}
 	source := []byte("test bytes converter")
 	expected := "dGVzdCBieXRlcyBjb252ZXJ0ZXI="
-	actual, err := c.Convert(source)
+	actual, err := c.Convert("blob", source)
 
 	assert.Nil(t, err)
 	assert.EqualValues(t, expected, actual)

--- a/dataconv/converter.go
+++ b/dataconv/converter.go
@@ -1,7 +1,7 @@
 package dataconv
 
 type Converter interface {
-	Convert(interface{}) (interface{}, error)
+	Convert(string, interface{}) (interface{}, error)
 	Handle(interface{}) bool
 }
 

--- a/dataconv/converter_test.go
+++ b/dataconv/converter_test.go
@@ -9,7 +9,7 @@ import (
 
 type DummyConverter string
 
-func (DummyConverter) Convert(interface{}) (interface{}, error) {
+func (DummyConverter) Convert(string, interface{}) (interface{}, error) {
 	return 0, nil
 }
 

--- a/dataconv/date_time_iso8601_converter.go
+++ b/dataconv/date_time_iso8601_converter.go
@@ -12,7 +12,7 @@ const (
 	dateTimeISO8601Layout = "2006-01-02T15:04:05.999 -0700"
 )
 
-func (DateTimeISO8601Converter) Convert(source interface{}) (interface{}, error) {
+func (DateTimeISO8601Converter) Convert(_ string, source interface{}) (interface{}, error) {
 	tm, isTime := source.(time.Time)
 	if !isTime {
 		return nil, fmt.Errorf("'%v' is not time.Time", source)

--- a/dataconv/date_time_iso8601_converter_test.go
+++ b/dataconv/date_time_iso8601_converter_test.go
@@ -11,7 +11,7 @@ import (
 func TestConvertTimeSourceIsNotTime(t *testing.T) {
 	c := dataconv.DateTimeISO8601Converter{}
 	source := "2023-06-09T14:31:16.478 -0300"
-	actual, err := c.Convert(source)
+	actual, err := c.Convert("datetime", source)
 
 	assert.Equal(t, "'2023-06-09T14:31:16.478 -0300' is not time.Time", err.Error())
 	assert.Nil(t, actual)
@@ -22,7 +22,7 @@ func TestConvertDateAndTime(t *testing.T) {
 	location, _ := time.LoadLocation("America/Sao_Paulo")
 	source := time.Date(2023, time.June, 9, 14, 31, 16, 478587456, location)
 	expected := "2023-06-09T14:31:16.478 -0300"
-	actual, err := c.Convert(source)
+	actual, err := c.Convert("datetime", source)
 
 	assert.Nil(t, err)
 	assert.EqualValues(t, expected, actual)
@@ -33,7 +33,7 @@ func TestConvertDateOnly(t *testing.T) {
 	location, _ := time.LoadLocation("America/Sao_Paulo")
 	source := time.Date(2023, time.June, 19, 0, 0, 0, 0, location)
 	expected := "2023-06-19"
-	actual, err := c.Convert(source)
+	actual, err := c.Convert("datetime", source)
 
 	assert.Nil(t, err)
 	assert.EqualValues(t, expected, actual)

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -28,7 +28,7 @@ type Conf struct {
 
 type dbResponse struct {
 	table string
-	data  []map[string]interface{}
+	data  [][]*reader.DBColumn
 	err   error
 }
 
@@ -191,18 +191,18 @@ func writeData(c chan dbResponse, w writer.FileWriter) {
 
 func updateReferences(model schema.Model, response dbResponse) {
 	for _, record := range response.data {
-		for k, v := range record {
-			key := strings.ToLower(fmt.Sprintf("%s.%s", response.table, k))
+		for _, column := range record {
+			key := strings.ToLower(fmt.Sprintf("%s.%s", response.table, column.Name))
 			if _, exist := model.Refs[key]; exist {
-				model.Refs[key] = v
+				model.Refs[key] = column.Value
 			} else {
-				key = strings.ToLower(fmt.Sprintf("%s.%s[@]", response.table, k))
+				key = strings.ToLower(fmt.Sprintf("%s.%s[@]", response.table, column.Name))
 				if _, exist = model.Refs[key]; exist {
 					if model.Refs[key] == nil {
 						model.Refs[key] = make([]interface{}, 0)
 					}
 
-					model.Refs[key] = append(model.Refs[key].([]interface{}), v)
+					model.Refs[key] = append(model.Refs[key].([]interface{}), column.Value)
 				}
 			}
 		}

--- a/extractor/extractor_test.go
+++ b/extractor/extractor_test.go
@@ -128,137 +128,124 @@ func (FetchDataErrorDummyReader) FetchColumnsMetadata(schema.Table) ([]reader.DB
 }
 
 func (DummyReader) FetchData(table string, _ []reader.DBColumn, _ []dataconv.Converter,
-	_ [][]interface{}) ([]map[string]interface{}, error) {
+	_ [][]interface{}) ([][]*reader.DBColumn, error) {
 	switch {
 	case table == "customers":
-		m := make(map[string]interface{})
-		m["id"] = 34
-		m["first_name"] = "Antonio"
-		m["last_name"] = "Vivaldi"
-		return []map[string]interface{}{m}, nil
+		return [][]*reader.DBColumn{{
+			{Name: "id", Value: 34},
+			{Name: "first_name", Value: "Antonio"},
+			{Name: "last_name", Value: "Vivaldi"},
+		}}, nil
 	case table == "orders":
-		m := make(map[string]interface{})
-		m["id"] = 63
-		m["status"] = "paid"
-		m["total"] = 165.88
-		m["tax"] = 15.08
-		return []map[string]interface{}{m}, nil
+		return [][]*reader.DBColumn{{
+			{Name: "id", Value: 63},
+			{Name: "status", Value: "paid"},
+			{Name: "total", Value: 165.88},
+			{Name: "tax", Value: 15.08},
+		}}, nil
 	case table == "orders_customers":
-		m := make(map[string]interface{})
-		m["order_id"] = 63
-		m["customer_id"] = 34
-		return []map[string]interface{}{m}, nil
+		return [][]*reader.DBColumn{{
+			{Name: "order_id", Value: 63},
+			{Name: "customer_id", Value: 34},
+		}}, nil
 	case table == "products":
-		m := make(map[string]interface{})
-		m["id"] = 3
-		m["name"] = "Holy Bible"
-		m["description"] = "Latin Vulgata from Saint Jerome"
-		m["price"] = 150.8
-		return []map[string]interface{}{m}, nil
+		return [][]*reader.DBColumn{{
+			{Name: "id", Value: 3},
+			{Name: "name", Value: "Holy Bible"},
+			{Name: "description", Value: "Latin Vulgata from Saint Jerome"},
+			{Name: "price", Value: 150.8},
+		}}, nil
 	default:
-		return []map[string]interface{}{}, nil
+		return [][]*reader.DBColumn{}, nil
 	}
 }
 
 func (HumanResourcesReader) FetchData(table string, _ []reader.DBColumn, _ []dataconv.Converter,
-	_ [][]interface{}) ([]map[string]interface{}, error) {
+	_ [][]interface{}) ([][]*reader.DBColumn, error) {
 	switch {
 	case table == "employees":
-		m1 := make(map[string]interface{})
-		m1["id"] = 100
-		m1["department_id"] = 90
-		m1["job_id"] = 5
-		m1["first_name"] = "Antonio"
-		m1["last_name"] = "Vivaldi"
-
-		m2 := make(map[string]interface{})
-		m2["id"] = 101
-		m2["department_id"] = 90
-		m2["job_id"] = 3
-		m2["first_name"] = "Johann"
-		m2["last_name"] = "Bach"
-
-		return []map[string]interface{}{m1, m2}, nil
+		return [][]*reader.DBColumn{{
+			{Name: "id", Value: 100},
+			{Name: "department_id", Value: 90},
+			{Name: "job_id", Value: 5},
+			{Name: "first_name", Value: "Antonio"},
+			{Name: "last_name", Value: "Vivaldi"},
+		}, {
+			{Name: "id", Value: 101},
+			{Name: "department_id", Value: 90},
+			{Name: "job_id", Value: 3},
+			{Name: "first_name", Value: "Johann"},
+			{Name: "last_name", Value: "Bach"},
+		}}, nil
 	case table == "departments":
-		m := make(map[string]interface{})
-		m["id"] = 90
-		m["location_id"] = 1700
-		m["name"] = "Sales"
-		return []map[string]interface{}{m}, nil
+		return [][]*reader.DBColumn{{
+			{Name: "id", Value: 90},
+			{Name: "location_id", Value: 1700},
+			{Name: "name", Value: "Sales"},
+		}}, nil
 	case table == "locations":
-		m := make(map[string]interface{})
-		m["id"] = 1700
-		m["country_id"] = 55
-		m["city"] = "Governador Valadares"
-		m["province"] = "Minas Gerais"
-		return []map[string]interface{}{m}, nil
+		return [][]*reader.DBColumn{{
+			{Name: "id", Value: 1700},
+			{Name: "country_id", Value: 55},
+			{Name: "city", Value: "Governador Valadares"},
+			{Name: "province", Value: "Minas Gerais"},
+		}}, nil
 	case table == "countries":
-		m := make(map[string]interface{})
-		m["id"] = 55
-		m["region_id"] = 3
-		m["name"] = "Brasil"
-		return []map[string]interface{}{m}, nil
+		return [][]*reader.DBColumn{{{Name: "id", Value: 55},
+			{Name: "region_id", Value: 3},
+			{Name: "name", Value: "Brasil"},
+		}}, nil
 	case table == "regions":
-		m := make(map[string]interface{})
-		m["id"] = 3
-		m["name"] = "América do Sul"
-		return []map[string]interface{}{m}, nil
+		return [][]*reader.DBColumn{{
+			{Name: "id", Value: 3},
+			{Name: "name", Value: "América do Sul"},
+		}}, nil
 	case table == "jobs":
-		m1 := make(map[string]interface{})
-		m1["id"] = 1
-		m1["title"] = "junior developer"
-
-		m2 := make(map[string]interface{})
-		m2["id"] = 2
-		m2["title"] = "full developer"
-
-		m3 := make(map[string]interface{})
-		m3["id"] = 3
-		m3["title"] = "senior developer"
-
-		m4 := make(map[string]interface{})
-		m4["id"] = 4
-		m4["title"] = "seller"
-
-		m5 := make(map[string]interface{})
-		m5["id"] = 5
-		m5["title"] = "sell manager"
-
-		return []map[string]interface{}{m1, m2, m3, m4, m5}, nil
+		return [][]*reader.DBColumn{{
+			{Name: "id", Value: 1},
+			{Name: "title", Value: "junior developer"},
+		}, {
+			{Name: "id", Value: 2},
+			{Name: "title", Value: "full developer"},
+		}, {
+			{Name: "id", Value: 3},
+			{Name: "title", Value: "senior developer"},
+		}, {
+			{Name: "id", Value: 4},
+			{Name: "title", Value: "seller"},
+		}, {
+			{Name: "id", Value: 5},
+			{Name: "title", Value: "sell manager"},
+		}}, nil
 	case table == "job_history":
-		m1 := make(map[string]interface{})
-		m1["employee_id"] = 100
-		m1["job_id"] = 4
-
-		m2 := make(map[string]interface{})
-		m2["employee_id"] = 100
-		m2["job_id"] = 5
-
-		m3 := make(map[string]interface{})
-		m3["employee_id"] = 101
-		m3["job_id"] = 1
-
-		m4 := make(map[string]interface{})
-		m4["employee_id"] = 101
-		m4["job_id"] = 2
-
-		m5 := make(map[string]interface{})
-		m5["employee_id"] = 101
-		m5["job_id"] = 3
-
-		return []map[string]interface{}{m1, m2, m3, m4, m5}, nil
+		return [][]*reader.DBColumn{{
+			{Name: "employee_id", Value: 100},
+			{Name: "job_id", Value: 4},
+		}, {
+			{Name: "employee_id", Value: 100},
+			{Name: "job_id", Value: 5},
+		}, {
+			{Name: "employee_id", Value: 101},
+			{Name: "job_id", Value: 1},
+		}, {
+			{Name: "employee_id", Value: 101},
+			{Name: "job_id", Value: 2},
+		}, {
+			{Name: "employee_id", Value: 101},
+			{Name: "job_id", Value: 3},
+		}}, nil
 	default:
-		return []map[string]interface{}{}, nil
+		return [][]*reader.DBColumn{}, nil
 	}
 }
 
 func (FetchMetadataErrorDummyReader) FetchData(string, []reader.DBColumn, []dataconv.Converter,
-	[][]interface{}) ([]map[string]interface{}, error) {
-	return []map[string]interface{}{}, nil
+	[][]interface{}) ([][]*reader.DBColumn, error) {
+	return [][]*reader.DBColumn{}, nil
 }
 
 func (FetchDataErrorDummyReader) FetchData(string, []reader.DBColumn, []dataconv.Converter,
-	[][]interface{}) ([]map[string]interface{}, error) {
+	[][]interface{}) ([][]*reader.DBColumn, error) {
 	return nil, fmt.Errorf("fetch data error")
 }
 
@@ -306,11 +293,11 @@ func (DummyWriter) Write(string, []map[string]interface{}) error {
 	return nil
 }
 
-func (WriteDataErrorDummyWriter) Write(string, []map[string]interface{}) error {
+func (WriteDataErrorDummyWriter) Write(string, [][]*reader.DBColumn) error {
 	return fmt.Errorf("write data error")
 }
 
-func (WriteDataHeaderErrorDummyWriter) Write(string, []map[string]interface{}) error {
+func (WriteDataHeaderErrorDummyWriter) Write(string, [][]*reader.DBColumn) error {
 	return nil
 }
 

--- a/extractor/extractor_test.go
+++ b/extractor/extractor_test.go
@@ -18,7 +18,7 @@ import (
 
 type DummyConverter string
 
-func (DummyConverter) Convert(interface{}) (interface{}, error) {
+func (DummyConverter) Convert(string, interface{}) (interface{}, error) {
 	return 0, nil
 }
 

--- a/reader/oracle.go
+++ b/reader/oracle.go
@@ -253,7 +253,7 @@ func readDataSet(fields []DBColumn, rows *sql.Rows, converters []dataconv.Conver
 		}
 
 		for i := range columns {
-			value, err := fetchValue(values[i], converters)
+			value, err := fetchValue(row[i].Type, values[i], converters)
 			if err != nil {
 				log.Printf("Oracle.readDataSet\nFetch value error: %s\n", err.Error())
 				log.Printf("Field: %s - Value: %v\n", columns[i], values[i])
@@ -269,10 +269,10 @@ func readDataSet(fields []DBColumn, rows *sql.Rows, converters []dataconv.Conver
 	return data, rows.Err()
 }
 
-func fetchValue(value interface{}, converters []dataconv.Converter) (interface{}, error) {
+func fetchValue(dtype string, value interface{}, converters []dataconv.Converter) (interface{}, error) {
 	converter := findConverter(value, converters)
 	if converter != nil {
-		return converter.Convert(value)
+		return converter.Convert(dtype, value)
 	}
 
 	return value, nil

--- a/reader/oracle.go
+++ b/reader/oracle.go
@@ -256,6 +256,7 @@ func readDataSet(fields []DBColumn, rows *sql.Rows, converters []dataconv.Conver
 			value, err := fetchValue(values[i], converters)
 			if err != nil {
 				log.Printf("Oracle.readDataSet\nFetch value error: %s\n", err.Error())
+				log.Printf("Field: %s - Value: %v\n", columns[i], values[i])
 				return nil, err
 			}
 

--- a/reader/oracle_test.go
+++ b/reader/oracle_test.go
@@ -19,7 +19,7 @@ import (
 
 type DummyConverter struct{}
 
-func (DummyConverter) Convert(interface{}) (interface{}, error) {
+func (DummyConverter) Convert(string, interface{}) (interface{}, error) {
 	return nil, fmt.Errorf("converter error")
 }
 

--- a/reader/oracle_test.go
+++ b/reader/oracle_test.go
@@ -275,12 +275,12 @@ func TestFetchData(t *testing.T) {
 	require.Nil(t, err)
 
 	assert.Len(t, data, 1)
-	assert.EqualValues(t, 4, data[0]["ID"])
-	assert.EqualValues(t, 375, data[0]["USER_ID"])
-	assert.Equal(t, "SOLD", data[0]["STATUS"])
-	assert.EqualValues(t, 2243.72, data[0]["TOTAL"])
-	assert.Equal(t, dateRec.Format("2006-01-02T15:04:05.999 -0700"), data[0]["DATE_REC"])
-	assert.Equal(t, "aGVsbG8gd29ybGQ=", data[0]["ATTACHMENT"])
+	assert.EqualValues(t, 4, data[0][0].Value)
+	assert.EqualValues(t, 375, data[0][1].Value)
+	assert.Equal(t, "SOLD", data[0][2].Value)
+	assert.EqualValues(t, 2243.72, data[0][3].Value)
+	assert.Equal(t, dateRec.Format("2006-01-02T15:04:05.999 -0700"), data[0][4].Value)
+	assert.Equal(t, "aGVsbG8gd29ybGQ=", data[0][5].Value)
 }
 
 func TestFetchDataNotAllFieldsWereBound(t *testing.T) {
@@ -350,10 +350,10 @@ func TestFetchDataFiltered(t *testing.T) {
 	require.Nil(t, err)
 
 	assert.Len(t, data, 1)
-	assert.EqualValues(t, 4, data[0]["ID"])
-	assert.EqualValues(t, 375, data[0]["USER_ID"])
-	assert.Equal(t, "SOLD", data[0]["STATUS"])
-	assert.EqualValues(t, 2243.72, data[0]["TOTAL"])
+	assert.EqualValues(t, 4, data[0][0].Value)
+	assert.EqualValues(t, 375, data[0][1].Value)
+	assert.Equal(t, "SOLD", data[0][2].Value)
+	assert.EqualValues(t, 2243.72, data[0][3].Value)
 }
 
 func TestFetchDataPrepareError(t *testing.T) {

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -23,6 +23,7 @@ type DBColumn struct {
 	Nullable    bool
 	Length      int64
 	DecimalSize DecimalColumn
+	Value       interface{}
 }
 
 var ErrUnsupportedDBReader = errors.New("unsupported database")
@@ -31,7 +32,7 @@ const DBSnapshotDealy = time.Millisecond * 200
 
 type DBReader interface {
 	FetchColumnsMetadata(schema.Table) ([]DBColumn, error)
-	FetchData(string, []DBColumn, []dataconv.Converter, [][]interface{}) ([]map[string]interface{}, error)
+	FetchData(string, []DBColumn, []dataconv.Converter, [][]interface{}) ([][]*DBColumn, error)
 	ProfilerMode() bool
 	StartDBProfiler(context.Context)
 }

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -12,7 +12,7 @@ import (
 
 type DummyConverter string
 
-func (DummyConverter) Convert(interface{}) (interface{}, error) {
+func (DummyConverter) Convert(string, interface{}) (interface{}, error) {
 	return 0, nil
 }
 

--- a/writer/console.go
+++ b/writer/console.go
@@ -3,6 +3,8 @@ package writer
 import (
 	"fmt"
 	"os"
+
+	"github.com/aureliano/db-unit-extractor/reader"
 )
 
 type ConsoleWriter struct{}
@@ -15,13 +17,13 @@ func (*ConsoleWriter) WriteFooter() error {
 	return nil
 }
 
-func (*ConsoleWriter) Write(table string, rows []map[string]interface{}) error {
+func (*ConsoleWriter) Write(table string, rows [][]*reader.DBColumn) error {
 	for _, row := range rows {
 		fmt.Fprintln(os.Stdout, " >", table)
 
-		for name, value := range row {
-			if value != nil {
-				fmt.Fprintf(os.Stdout, "   %s: %v\n", name, value)
+		for _, column := range row {
+			if column.Value != nil {
+				fmt.Fprintf(os.Stdout, "   %s: %v\n", column.Name, column.Value)
 			}
 		}
 	}

--- a/writer/console_test.go
+++ b/writer/console_test.go
@@ -3,6 +3,7 @@ package writer_test
 import (
 	"testing"
 
+	"github.com/aureliano/db-unit-extractor/reader"
 	"github.com/aureliano/db-unit-extractor/writer"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,15 +21,9 @@ func TestConsoleWriteFooter(t *testing.T) {
 func TestConsoleWrite(t *testing.T) {
 	w := writer.ConsoleWriter{}
 
-	rows := make([]map[string]interface{}, 2)
-
-	row := make(map[string]interface{})
-	row["id"] = 1
-	rows[0] = row
-
-	row = make(map[string]interface{})
-	row["name"] = "Giovanni Pierluigi da Palestrina"
-	rows[1] = row
+	rows := make([][]*reader.DBColumn, 2)
+	rows[0] = []*reader.DBColumn{{Name: "id", Value: 1}, {}}
+	rows[1] = []*reader.DBColumn{{}, {Name: "name", Value: "Giovanni Pierluigi da Palestrina"}}
 
 	err := w.Write("", rows)
 	assert.Nil(t, err)

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/aureliano/db-unit-extractor/reader"
 )
 
 type FileConf struct {
@@ -18,7 +20,7 @@ var ErrUnsupportedFileWriter = errors.New("unsupported file type")
 type FileWriter interface {
 	WriteHeader() error
 	WriteFooter() error
-	Write(table string, rows []map[string]interface{}) error
+	Write(table string, rows [][]*reader.DBColumn) error
 }
 
 func NewWriter(conf FileConf) (FileWriter, error) {

--- a/writer/xml.go
+++ b/writer/xml.go
@@ -91,7 +91,7 @@ func formattedXMLRecord(table string, rows [][]*reader.DBColumn) []byte {
 		sb.WriteString(fmt.Sprintf("  <%s", table))
 
 		for _, column := range row {
-			if column != nil {
+			if column.Value != nil {
 				sb.WriteString(fmt.Sprintf("\n    %s=\"%v\"", column.Name, column.Value))
 			}
 		}
@@ -107,7 +107,7 @@ func unformattedXMLRecord(table string, rows [][]*reader.DBColumn) []byte {
 	for _, row := range rows {
 		sb.WriteString(fmt.Sprintf("<%s", table))
 		for _, column := range row {
-			if column != nil {
+			if column.Value != nil {
 				sb.WriteString(fmt.Sprintf(" %s=\"%v\"", column.Name, column.Value))
 			}
 		}

--- a/writer/xml.go
+++ b/writer/xml.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/aureliano/db-unit-extractor/reader"
 )
 
 type XMLWriter struct {
@@ -51,7 +53,7 @@ func (w *XMLWriter) WriteFooter() error {
 	return w.file.Close()
 }
 
-func (w *XMLWriter) Write(table string, rows []map[string]interface{}) error {
+func (w *XMLWriter) Write(table string, rows [][]*reader.DBColumn) error {
 	content := fileBody(w.Formatted, table, rows)
 	_, err := w.file.Write(content)
 	if err != nil {
@@ -74,7 +76,7 @@ func fileFooter() []byte {
 	return []byte("</dataset>")
 }
 
-func fileBody(formatted bool, table string, rows []map[string]interface{}) []byte {
+func fileBody(formatted bool, table string, rows [][]*reader.DBColumn) []byte {
 	if formatted {
 		return formattedXMLRecord(table, rows)
 	}
@@ -82,15 +84,15 @@ func fileBody(formatted bool, table string, rows []map[string]interface{}) []byt
 	return unformattedXMLRecord(table, rows)
 }
 
-func formattedXMLRecord(table string, rows []map[string]interface{}) []byte {
+func formattedXMLRecord(table string, rows [][]*reader.DBColumn) []byte {
 	sb := strings.Builder{}
 
 	for _, row := range rows {
 		sb.WriteString(fmt.Sprintf("  <%s", table))
 
-		for name, value := range row {
-			if value != nil {
-				sb.WriteString(fmt.Sprintf("\n    %s=\"%v\"", name, value))
+		for _, column := range row {
+			if column != nil {
+				sb.WriteString(fmt.Sprintf("\n    %s=\"%v\"", column.Name, column.Value))
 			}
 		}
 		sb.WriteString("/>\n")
@@ -99,14 +101,14 @@ func formattedXMLRecord(table string, rows []map[string]interface{}) []byte {
 	return []byte(sb.String())
 }
 
-func unformattedXMLRecord(table string, rows []map[string]interface{}) []byte {
+func unformattedXMLRecord(table string, rows [][]*reader.DBColumn) []byte {
 	sb := strings.Builder{}
 
 	for _, row := range rows {
 		sb.WriteString(fmt.Sprintf("<%s", table))
-		for name, value := range row {
-			if value != nil {
-				sb.WriteString(fmt.Sprintf(" %s=\"%v\"", name, value))
+		for _, column := range row {
+			if column != nil {
+				sb.WriteString(fmt.Sprintf(" %s=\"%v\"", column.Name, column.Value))
 			}
 		}
 		sb.WriteString("/>")

--- a/writer/xml_test.go
+++ b/writer/xml_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aureliano/db-unit-extractor/reader"
 	"github.com/aureliano/db-unit-extractor/writer"
 	"github.com/stretchr/testify/assert"
 
@@ -61,7 +62,7 @@ func TestWriteBodyFileWritingError(t *testing.T) {
 	defer patches.Reset()
 
 	w := writer.XMLWriter{Directory: filepath.Join(os.TempDir(), "db-unit-extractor", "writer")}
-	assert.Equal(t, "file writing error", w.Write("", make([]map[string]interface{}, 2)).Error())
+	assert.Equal(t, "file writing error", w.Write("", make([][]*reader.DBColumn, 2)).Error())
 }
 
 func TestWriteUnformatted(t *testing.T) {
@@ -74,14 +75,13 @@ func TestWriteUnformatted(t *testing.T) {
 
 	assert.Nil(t, w.WriteHeader())
 
-	row := make(map[string]interface{})
-	row["id"] = 1
-	row["name"] = "shirt"
-	row["description"] = "black shirt"
-	row["price"] = 14.50
-
-	rows := make([]map[string]interface{}, 2)
-	rows[0] = row
+	rows := make([][]*reader.DBColumn, 2)
+	rows[0] = []*reader.DBColumn{
+		{Name: "id", Value: 1},
+		{Name: "name", Value: "shirt"},
+		{Name: "description", Value: "black shirt"},
+		{Name: "price", Value: 14.50},
+	}
 
 	assert.Nil(t, w.Write("products", rows))
 
@@ -108,14 +108,13 @@ func TestWriteFormatted(t *testing.T) {
 
 	assert.Nil(t, w.WriteHeader())
 
-	row := make(map[string]interface{})
-	row["id"] = 1
-	row["name"] = "shirt"
-	row["description"] = "black shirt"
-	row["price"] = 14.50
-
-	rows := make([]map[string]interface{}, 2)
-	rows[0] = row
+	rows := make([][]*reader.DBColumn, 2)
+	rows[0] = []*reader.DBColumn{
+		{Name: "id", Value: 1},
+		{Name: "name", Value: "shirt"},
+		{Name: "description", Value: "black shirt"},
+		{Name: "price", Value: 14.50},
+	}
 
 	assert.Nil(t, w.Write("products", rows))
 


### PR DESCRIPTION
Change reader.FetchData signature in order to return a bidimensional array of reader.DBColumn pointer. Closes #77.