### PR TITLE
75 print final schema data set when parsing fail

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -61,13 +61,18 @@ type DataTable interface {
 
 func DigestSchema(fpath string) (Model, error) {
 	schema := Model{}
-	yml, err := os.ReadFile(fpath)
+	bytes, err := os.ReadFile(fpath)
 
 	if err != nil {
 		return schema, fmt.Errorf("%w: %w", ErrSchemaFile, err)
 	}
 
-	if err = yaml.UnmarshalStrict(yml, &schema); err != nil {
+	yml, err := ApplyTemplates(fpath, string(bytes))
+	if err != nil {
+		return schema, fmt.Errorf("%w: %w", ErrSchemaFile, err)
+	}
+
+	if err = yaml.UnmarshalStrict([]byte(yml), &schema); err != nil {
 		return schema, fmt.Errorf("%w: %w", ErrSchemaFile, err)
 	}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"regexp"
 	"strings"
@@ -69,10 +70,12 @@ func DigestSchema(fpath string) (Model, error) {
 
 	yml, err := ApplyTemplates(fpath, string(bytes))
 	if err != nil {
+		log.Printf("Could not parse template at %s\n", fpath)
 		return schema, fmt.Errorf("%w: %w", ErrSchemaFile, err)
 	}
 
 	if err = yaml.UnmarshalStrict([]byte(yml), &schema); err != nil {
+		log.Printf("Final data-set schema:\n%s\n", yml)
 		return schema, fmt.Errorf("%w: %w", ErrSchemaFile, err)
 	}
 

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -33,7 +33,7 @@ func TestDigestSchemaUnmarshalError(t *testing.T) {
 func TestDigestSchemaTemplatingError(t *testing.T) {
 	_, err := schema.DigestSchema("../test/unit/schema_test_templating_error.yml")
 	assert.ErrorIs(t, err, schema.ErrSchemaFile)
-	assert.Contains(t,
+	assert.Equal(t,
 		"schema-file: invalid template definition `<%= template path=\"_domain-customer.yml\" param 123 %>'",
 		err.Error())
 }

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -30,6 +30,14 @@ func TestDigestSchemaUnmarshalError(t *testing.T) {
 	assert.Contains(t, err.Error(), "yaml: unmarshal errors")
 }
 
+func TestDigestSchemaTemplatingError(t *testing.T) {
+	_, err := schema.DigestSchema("../test/unit/schema_test_templating_error.yml")
+	assert.ErrorIs(t, err, schema.ErrSchemaFile)
+	assert.Contains(t,
+		"schema-file: invalid template definition `<%= template path=\"_domain-customer.yml\" param 123 %>'",
+		err.Error())
+}
+
 func TestDigestSchemaUnmarshalErrorUnknownField(t *testing.T) {
 	_, err := schema.DigestSchema("../test/unit/schema_test_unmarshal_error_unknown_field.yml")
 	assert.Contains(t, err.Error(), "line 7: field ArbitraryField not found in type schema.Table")

--- a/test/unit/schema_test_templating_error.yml
+++ b/test/unit/schema_test_templating_error.yml
@@ -1,0 +1,3 @@
+---
+tables:
+  <%= template path="_domain-customer.yml" param 123 %>


### PR DESCRIPTION
Improves logging when schema parsing fails. Closes #75.